### PR TITLE
Agregar readme del proyecto

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Este es el repositorio principal para el proyecto de investigación en Imágenes Médicas -> Patología digital, de la UTN-FRC
 
-## Contributing
+## Contribuir
 
 Para contribuir, ponete en contacto con nosotros escribiendonos a patologia.digital.utn@gmail.com
 
-## License
+## Licencia
 
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# PatoUTN - Repositorio principal
+
+Este es el repositorio principal para el proyecto de investigación en Imágenes Médicas -> Patología digital, de la UTN-FRC
+
+## Contributing
+
+Para contribuir, ponete en contacto con nosotros escribiendonos a patologia.digital.utn@gmail.com
+
+## License
+
+[MIT](https://choosealicense.com/licenses/mit/)


### PR DESCRIPTION
Se agregó el archivo readme como ejemplo para el flujo de trabajo al trabajar con historias de usuario que requiren subir código a un repositorio de PatoUTN